### PR TITLE
Fix: last pager element is not activated.

### DIFF
--- a/src/jquery.fs.roller.js
+++ b/src/jquery.fs.roller.js
@@ -637,7 +637,7 @@
 			}
 		}
 
-		if (animate !== false && index !== data.index && (data.infinite || (index > -1 && index < data.pageCount)) ) {
+		if (animate !== false && index !== data.index && (data.infinite || (index > -1 && index < data.pageCount + 1)) ) {
 			data.$roller.trigger("update.roller", [ index ]);
 			data.index = index;
 		}


### PR DESCRIPTION
This fixes issue for pagination, when clicking on last page item it's not set active, but previous page is activated instead.
